### PR TITLE
Fixes for amcache file attributes.

### DIFF
--- a/Amcache/Amcache.cs
+++ b/Amcache/Amcache.cs
@@ -17,22 +17,22 @@ namespace Amcache
         private const int SwitchBackContext = 0x4;
         private const int FileVersionString = 0x5;
         private const int FileSize = 0x6;
-        private const int PEHeaderSize = 0x7;
+        private const int SizeOfImage = 0x7;
         private const int PEHeaderHash = 0x8;
         private const int PEHeaderChecksum = 0x9;
-        private const int Unknown1 = 0xa;
-        private const int Unknown2 = 0xb;
+        private const int BinProductVersion = 0xa;
+        private const int BinFileVersion = 0xb;
         private const int FileDescription = 0xc;
-        private const int Unknown3 = 0xd;
-        private const int CompileTime = 0xf;
-        private const int Unknown4 = 0x10;
+        private const int LinkerVersion = 0xd;
+        private const int LinkDate = 0xf;
+        private const int BinaryType = 0x10;
         private const int LastModified = 0x11;
         private const int Created = 0x12;
         private const int FullPath = 0x15;
-        private const int Unknown5 = 0x16;
-        private const int LastModified2 = 0x17;
+        private const int IsLocal = 0x16;
+        private const int LastModifiedStore = 0x17;
         private const int ProgramID = 0x100;
-        private const int Unknown6 = 0x106;
+        private const int GuessProgramID = 0x106;
         private const int SHA1 = 0x101;
         private static Logger _logger;
 
@@ -214,20 +214,20 @@ namespace Amcache
                     var progID = "";
                     var sha = "";
 
-                    long unknown1 = 0;
-                    ulong unknown2 = 0;
-                    var unknown3 = 0;
-                    var unknown4 = 0;
-                    var unknown5 = 0;
-                    var unknown6 = 0;
+                    long binProdVersion = 0;
+                    ulong binFileVersion = 0;
+                    var linkerVersion = 0;
+                    var binType = 0;
+                    var isLocal = 0;
+                    var gProgramID = 0;
                     int? fileSize = null;
-                    int? peHeaderSize = null;
+                    int? sizeOfImage = null;
                     int? peHeaderChecksum = null;
 
                     DateTimeOffset? created = null;
                     DateTimeOffset? lm = null;
-                    DateTimeOffset? lm2 = null;
-                    DateTimeOffset? compTime = null;
+                    DateTimeOffset? lmStore = null;
+                    DateTimeOffset? linkDate = null;
 
                     var hasLinkedProgram = false;
 
@@ -261,8 +261,8 @@ namespace Amcache
                                 case FileSize:
                                     fileSize = int.Parse(keyValue.ValueData);
                                     break;
-                                case PEHeaderSize:
-                                    peHeaderSize = int.Parse(keyValue.ValueData);
+                                case SizeOfImage:
+                                    sizeOfImage = int.Parse(keyValue.ValueData);
                                     break;
                                 case PEHeaderHash:
                                     peHash = keyValue.ValueData;
@@ -270,25 +270,25 @@ namespace Amcache
                                 case PEHeaderChecksum:
                                     peHeaderChecksum = int.Parse(keyValue.ValueData);
                                     break;
-                                case Unknown1:
-                                    unknown1 = long.Parse(keyValue.ValueData);
+                                case BinProductVersion:
+                                    binProdVersion = long.Parse(keyValue.ValueData);
                                     break;
-                                case Unknown2:
-                                    unknown2 = ulong.Parse(keyValue.ValueData);
+                                case BinFileVersion:
+                                    binFileVersion = ulong.Parse(keyValue.ValueData);
                                     break;
                                 case FileDescription:
                                     fileDesc = keyValue.ValueData;
                                     break;
-                                case Unknown3:
-                                    unknown3 = int.Parse(keyValue.ValueData);
+                                case LinkerVersion:
+                                    linkerVersion = int.Parse(keyValue.ValueData);
                                     break;
-                                case CompileTime:
-                                    compTime =
+                                case LinkDate:
+                                    linkDate =
                                         DateTimeOffset.FromUnixTimeSeconds(long.Parse(keyValue.ValueData))
                                             .ToUniversalTime();
                                     break;
-                                case Unknown4:
-                                    unknown4 = int.Parse(keyValue.ValueData);
+                                case BinaryType:
+                                    binType = int.Parse(keyValue.ValueData);
                                     break;
                                 case LastModified:
                                     lm = DateTimeOffset.FromFileTime(long.Parse(keyValue.ValueData)).ToUniversalTime();
@@ -300,14 +300,14 @@ namespace Amcache
                                 case FullPath:
                                     fullPath = keyValue.ValueData;
                                     break;
-                                case Unknown5:
-                                    unknown5 = int.Parse(keyValue.ValueData);
+                                case IsLocal:
+                                    isLocal = int.Parse(keyValue.ValueData);
                                     break;
-                                case Unknown6:
-                                    unknown6 = int.Parse(keyValue.ValueData);
+                                case GuessProgramID:
+                                    gProgramID = int.Parse(keyValue.ValueData);
                                     break;
-                                case LastModified2:
-                                    lm2 = DateTimeOffset.FromFileTime(long.Parse(keyValue.ValueData)).ToUniversalTime();
+                                case LastModifiedStore:
+                                    lmStore = DateTimeOffset.FromFileTime(long.Parse(keyValue.ValueData)).ToUniversalTime();
                                     break;
                                 case ProgramID:
                                     progID = keyValue.ValueData;
@@ -336,11 +336,11 @@ namespace Amcache
 
                         TotalFileEntries += 1;
 
-                        var fe = new FileEntry(prodName, progID, sha, fullPath, lm2, registryKey.KeyName,
+                        var fe = new FileEntry(prodName, progID, sha, fullPath, lmStore, registryKey.KeyName,
                             registryKey.LastWriteTime.Value, subKey.KeyName, subKey.LastWriteTime.Value,
-                            unknown5, compName, langId, fileVerString, peHash, fileVerNum, fileDesc, unknown1, unknown2,
-                            unknown3, unknown4, switchBack, fileSize, compTime, peHeaderSize,
-                            lm, created, peHeaderChecksum, unknown6, subKey.KeyName);
+                            isLocal, compName, langId, fileVerString, peHash, fileVerNum, fileDesc, binProdVersion, binFileVersion,
+                            linkerVersion, binType, switchBack, fileSize, linkDate, sizeOfImage,
+                            lm, created, peHeaderChecksum, gProgramID, subKey.KeyName);
 
                         if (hasLinkedProgram)
                         {

--- a/Amcache/Classes/FileEntry.cs
+++ b/Amcache/Classes/FileEntry.cs
@@ -5,18 +5,18 @@ namespace Amcache.Classes
 {
     public class FileEntry
     {
-        public FileEntry(string productName, string programID, string sha1, string fullPath, DateTimeOffset? lastMod2,
-            string volumeID, DateTimeOffset volumeLastWrite, string fileID, DateTimeOffset lastWrite, int unknown5,
+        public FileEntry(string productName, string programID, string sha1, string fullPath, DateTimeOffset? lmStore,
+            string volumeID, DateTimeOffset volumeLastWrite, string fileID, DateTimeOffset lastWrite, int isLocal,
             string compName, int? langId,
-            string fileVerString, string peHash, string fileVerNum, string fileDesc, long unknown1, ulong unknown2,
-            int unknown3, int unknown4, string switchback, int? fileSize, DateTimeOffset? compTime, int? peHeaderSize,
-            DateTimeOffset? lm, DateTimeOffset? created, int? pecheck, int unknown6, string keyName)
+            string fileVerString, string peHash, string fileVerNum, string fileDesc, long binProdVer, ulong binFileVer,
+            int linVer, int binType, string switchback, int? fileSize, DateTimeOffset? linkDate, int? imgSize,
+            DateTimeOffset? lm, DateTimeOffset? created, int? pecheck, int gProgramID, string keyName)
         {
             PEHeaderChecksum = pecheck;
             LastModified = lm;
             Created = created;
-            PEHeaderSize = peHeaderSize;
-            CompileTime = compTime;
+            SizeOfImage = imgSize;
+            LinkDate = linkDate;
             SwitchBackContext = switchback;
             FileSize = fileSize;
             FileDescription = fileDesc;
@@ -33,17 +33,17 @@ namespace Amcache.Classes
 
             FileExtension = Path.GetExtension(fullPath);
 
-            LastModified2 = lastMod2;
+            LastModifiedStore = lmStore;
             FileID = fileID;
             FileIDLastWriteTimestamp = lastWrite;
             VolumeID = volumeID;
             VolumeIDLastWriteTimestamp = volumeLastWrite;
-            Unknown1 = unknown1;
-            Unknown2 = unknown2;
-            Unknown3 = unknown3;
-            Unknown4 = unknown4;
-            Unknown5 = unknown5;
-            Unknown6 = unknown6;
+            BinProductVersion = binProdVer;
+            BinFileVersion = binFileVer;
+            LinkerVersion = linVer;
+            BinaryType = binType;
+            IsLocal = isLocal;
+            GuessProgramID = gProgramID;
             CompanyName = compName;
             LanguageID = langId;
             FileVersionString = fileVerString;
@@ -83,21 +83,21 @@ namespace Amcache.Classes
         public string VolumeID { get; }
         public string SwitchBackContext { get; }
         public string ProgramName { get; set; }
-        public long Unknown1 { get; }
-        public ulong Unknown2 { get; }
-        public int Unknown3 { get; }
-        public int Unknown4 { get; }
-        public int Unknown5 { get; }
-        public int Unknown6 { get; }
+        public long BinProductVersion { get; }
+        public ulong BinFileVersion { get; }
+        public int LinkerVersion { get; }
+        public int BinaryType { get; }
+        public int IsLocal { get; }
+        public int GuessProgramID { get; }
         public int? LanguageID { get; }
         public int? FileSize { get; }
-        public int? PEHeaderSize { get; }
+        public int? SizeOfImage { get; }
         public int? PEHeaderChecksum { get; }
         public DateTimeOffset VolumeIDLastWriteTimestamp { get; }
         public DateTimeOffset FileIDLastWriteTimestamp { get; }
-        public DateTimeOffset? CompileTime { get; }
+        public DateTimeOffset? LinkDate { get; }
         public DateTimeOffset? LastModified { get; }
-        public DateTimeOffset? LastModified2 { get; }
+        public DateTimeOffset? LastModifiedStore { get; }
         public DateTimeOffset? Created { get; }
 
         public static string Reverse(string s)

--- a/AmcacheParser/Program.cs
+++ b/AmcacheParser/Program.cs
@@ -403,14 +403,21 @@ namespace AmcacheParser
             Map(m => m.FileVersionNumber);
             Map(m => m.FileDescription);
 
-            Map(m => m.PEHeaderSize);
+            Map(m => m.SizeOfImage);
             Map(m => m.PEHeaderHash);
             Map(m => m.PEHeaderChecksum);
 
+            Map(m => m.BinProductVersion);
+            Map(m => m.BinFileVersion);
+            Map(m => m.LinkerVersion);
+            Map(m => m.BinaryType);
+            Map(m => m.IsLocal);
+            Map(m => m.GuessProgramID);
+
             Map(m => m.Created).TypeConverterOption(dateformat);
             Map(m => m.LastModified).TypeConverterOption(dateformat);
-            Map(m => m.LastModified2).TypeConverterOption(dateformat);
-            Map(m => m.CompileTime).TypeConverterOption(dateformat);
+            Map(m => m.LastModifiedStore).TypeConverterOption(dateformat);
+            Map(m => m.LinkDate).TypeConverterOption(dateformat);
             Map(m => m.LanguageID);
         }
     }


### PR DESCRIPTION
1. Replaced 'unknown' fields with obtained file attributes values:
	0xa -- BinProductVersion
	0xb -- BinFileVersion
	0xd -- LinkerVersion
	0x10 -- BinaryType
	0x16 -- isLocal
	0x106 -- GuessProgramID

2. Replaced LastModified2 and PEHeaderSize and CompileTime with correct values: LastModifiedStore, ImageSize and LinkDate